### PR TITLE
fix: use NEXT_PUBLIC_API_URL

### DIFF
--- a/app/api.config.ts
+++ b/app/api.config.ts
@@ -1,3 +1,3 @@
-const apiUrl = process.env.API_URL || "http://admin.localhost/admin";
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://admin.localhost/admin";
 
 export default apiUrl;


### PR DESCRIPTION
Allows variable to be set at runtime